### PR TITLE
New image helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 
 /bundles/*
 !/bundles/example
-!/bundles/default.txt
 
 /local/*
 !/local/example

--- a/include/ReadIni.ahk
+++ b/include/ReadIni.ahk
@@ -100,6 +100,7 @@ INISetup["MathRedTextHotkey"]       := {default:"#c"}
 INISetup["MathPastePureHotkey"]     := {default:"#v"}
 INISetup["MathSetUpHotkey"]         := {default:"#w"}
 INISetup["MathSnippetHelperHotkey"] := {default:"#h"}
+INISetup["MathImageHelperHotkey"]   := {default:"#+h"}
 INISetup["MathReloadAllHotkey"]     := {default:"#q"}
 ; JJ ADD END      
 

--- a/include/settings/MathImageHelperHotkey.ini
+++ b/include/settings/MathImageHelperHotkey.ini
@@ -1,0 +1,6 @@
+MathImageHelperHotkey=#+h
+;MathImageHelperHotkey Default: #+h
+;MathImageHelperHotkey !=Alt, ^ = Ctrl, + Shift, # = WinKey
+;MathImageHelperHotkey HotKey used to add a new image to Lintalist from the selected text (using dialogs). 
+;MathImageHelperHotkey See http://ahkscript.org/docs/Hotkeys.htm#Symbols and http://ahkscript.org/docs/KeyList.htm for other keys.
+;MathImageHelperHotkey If you want to disable MathImageHelperHotkey simply delete the hotkey above (e.g. make it empty)

--- a/lintalist.ahk
+++ b/lintalist.ahk
@@ -46,7 +46,7 @@ PluginMultiCaret:=0 ; TODOMC
 
 ; Title + Version are included in Title and used in #IfWinActive hotkeys and WinActivate
 Title=Lintalist for Math
-Version=1.9.6a
+Version=1.9.6b
 
 ; JJ EDIT BEGIN
 MathHelperSnippet := ""
@@ -220,17 +220,19 @@ Loop, parse, ProgramHotKeyList, CSV
 
 Hotkey, IfWinNotExist, ahk_group BundleHotkeys
 Hotkey, %StartSearchHotkey%, GUIStart
-; JJ ADD BEGIN
-If (MathSnippetHelperHotkey <> "")
-	Hotkey, %MathSnippetHelperHotkey%, MathSnippetHelperStart
-Hotkey, #+h, MathImageHelperStart
-; JJ ADD END
 If (StartOmniSearchHotkey <> "")
 	Hotkey, %StartOmniSearchHotkey%, GUIStartOmni
 If (QuickSearchHotkey <> "")
 	Hotkey, %QuickSearchHotkey%, ShortText
 If (ExitProgramHotKey <> "")
 	Hotkey, %ExitProgramHotKey%, SaveSettings
+; JJ ADD BEGIN
+; Set up snippet helper hotkeys
+If (MathSnippetHelperHotkey <> "")
+  Hotkey, %MathSnippetHelperHotkey%, MathSnippetHelperStart
+If (MathSnippetHelperHotkey <> "")
+  Hotkey, %MathImageHelperHotkey%, MathImageHelperStart
+; JJ ADD END
 Hotkey, IfWinNotExist
 
 ; JJ ADD BEGIN

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ features of Lintalist. More Lintalist documentation can be found at
   bundles/clips/ folder, and open a snippet creation dialog with some code
   that should not be changed. When the snippet is called, it will paste
   the contents of the copied clipboard to the open program. Please note that
-  this does not consistens paste math copied from Maple -- after a 
+  this does not consistently paste math copied from Maple – after a 
   computer reboot the formatting will not be correct.</dd>
 
   <dt>Paste Pure Text (Win + V)</dt>

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,15 @@ features of Lintalist. More Lintalist documentation can be found at
 
   <dt>Snippet Helper (Win + H)</dt>
   <dd>Add a new snippet from the selected text (using dialogs).</dd>
+  
+  <dt>Image helper (Win + Shift + H)</dt>
+  <dd>Add a new image (clipboard copy) from current clipboard (using dialogs).
+  This will store the current clipboard contents in a .clip file in the
+  bundles/clips/ folder, and open a snippet creation dialog with some code
+  that should not be changed. When the snippet is called, it will paste
+  the contents of the copied clipboard to the open program. Please note that
+  this does not consistens paste math copied from Maple -- after a 
+  computer reboot the formatting will not be correct.</dd>
 
   <dt>Paste Pure Text (Win + V)</dt>
   <dd>Pastes content of clipboard as pure text. This helps with some
@@ -64,15 +73,13 @@ features of Lintalist. More Lintalist documentation can be found at
 
   <dt>Link Plugin</dt>
   <dd>A plugin to insert links into Maple (and paste pure text to other
-    programs). As an example writing `This [[Link=http://dr.dk]] 
-    has a link`, will insert http://dr.dk as a link when pasted to Maple. In 
+    programs). As an example writing <code>This [[Link=http://dr.dk]] 
+    has a link</code>, will insert http://dr.dk as a link when pasted to Maple. In 
     the snippet editor, a selected URL can be given the link tag by 
     pressing <strong>Ctrl + L</strong>.</dd>
 
   <dt>Math Plugin</dt>
   <dd>A plugin to paste simple formulas to Maple. See more below.</dd>
-  
-
 </dl>
 
 ### Math Plugin


### PR DESCRIPTION
Add a new image (clipboard copy) from current clipboard (using dialogs).
  This will store the current clipboard contents in a .clip file in the
  bundles/clips/ folder, and open a snippet creation dialog with some code
  that should not be changed. When the snippet is called, it will paste
  the contents of the copied clipboard to the open program. Please note that
  this does not consistently paste math copied from Maple – after a 
  computer reboot the formatting will not be correct.

Default keyboard shortcut: Win + Shift + H